### PR TITLE
nftables-ctl: load rules in determinitic order

### DIFF
--- a/nftables-ctl
+++ b/nftables-ctl
@@ -38,7 +38,7 @@ function nft_clear_protocol() {
 
 
 function nftables_start() {
-	find /etc/nftables -maxdepth 1 -type f -print0 | \
+	find /etc/nftables -maxdepth 1 -type f -print0 -name '*.rules' | \
 		sort -z | xargs --null --no-run-if-empty --max-args=1 nft -f
 
 	if [ -t 0 ]


### PR DESCRIPTION
- handle embedded white space in file names by using null characters as file separator
- sort rules to allow a deterministic loading
- only process files
- also load rules not ending with .rules (as used by current userland ntftables tools)
