### PR TITLE
Add SPDX Licensing Headers

### DIFF
--- a/00-flush.rules
+++ b/00-flush.rules
@@ -1,4 +1,7 @@
 #!/bin/sbin/nft -f
+#
+# SPDX-License-Identifier: GPL-2.0
+# SPDX-URL: https://spdx.org/licenses/GPL-2.0.html
 
 # Flush first only, other *.rules files may pile on after this.
 flush ruleset

--- a/20-nat.rules
+++ b/20-nat.rules
@@ -1,4 +1,7 @@
 # Masquerading
+#
+# SPDX-License-Identifier: GPL-2.0
+# SPDX-URL: https://spdx.org/licenses/GPL-2.0.html
 
 # input here was wlan0, and output could go to either eth0 or tun0:
 define iface_in = wlan0

--- a/nftables.service
+++ b/nftables.service
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0
+# SPDX-URL: https://spdx.org/licenses/GPL-2.0.html
 [Unit]
 Description=nftables
 Documentation=man:nftables(8)

--- a/nftablesctl
+++ b/nftablesctl
@@ -1,4 +1,7 @@
 #!/bin/sh
+#
+# SPDX-License-Identifier: GPL-2.0
+# SPDX-URL: https://spdx.org/licenses/GPL-2.0.html
 
 set -e
 which nft > /dev/null


### PR DESCRIPTION
Abbreviated form licensing headers using Software Package Data Exchange (SPDX) ID syntax for GPL v2.0 per standalone "LICENSE" file in repository.

https://spdx.org/ids

Note: Squash Commits on Merge :-)