### PR TITLE
Fix race with interfaces going up.

### DIFF
--- a/nftables.service
+++ b/nftables.service
@@ -3,6 +3,8 @@
 [Unit]
 Description=nftables
 Documentation=man:nftables(8)
+Before=network-pre.target
+Wants=network-pre.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
From https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/

network-pre.target is a target that may be used to order services
before any network interface is configured. Its primary purpose is for
usage with firewall services that want to establish a firewall before
any network interface is up. It's a passive unit: you cannot start it
directly and it is not pulled in by the the network management service,
but by the service that wants to run before it. Network management
services hence should set After=network-pre.target, but avoid any
Wants=network-pre.target or even Requires=network-pre.target. Services
that want to be run before the network is configured should place
Before=network-pre.target and also set Wants=network-pre.target to pull
it in. This way, unless there's actually a service that needs to be
ordered before the network is up the target is not pulled in, hence
avoiding any unnecessary synchronization point.